### PR TITLE
use python-libinput that works on python3.12

### DIFF
--- a/global-hotkeys/requirements.txt
+++ b/global-hotkeys/requirements.txt
@@ -1,3 +1,3 @@
 dbus-python==1.3.2
 libevdev==0.11
-python-libinput @ git+https://github.com/OzymandiasTheGreat/python-libinput.git@e5bdb2f5d6cc67452f7af32ecf9bcce4e6f2d8d8
+python-libinput @ git+https://github.com/agrif/python-libinput.git@b7284620566ce6791943c5cea721414e3b6d0c49


### PR DESCRIPTION
[Here's the python-libinput commit](https://github.com/agrif/python-libinput/commit/b7284620566ce6791943c5cea721414e3b6d0c49). Upstream repo is archived, I can't open a PR there. Not really sure if there's a logical, maintained successor.
